### PR TITLE
Migrate ETH to Maker-vDAI

### DIFF
--- a/vETH.md
+++ b/vETH.md
@@ -1,0 +1,7 @@
+# vETH pool
+|Strategy | Weight |
+|-------: | --------|
+|Compound | 0%     |
+|Aave| 0%     |
+|Maker-vDAI | 100%     |
+|Pool buffer | 0%     |


### PR DESCRIPTION
Better yield + higher upside on Maker-vDAI @ 275% collateralization and using ETH-C vault (0.5% stability fee)

100% because vETH is a v2 pool.