### PR TITLE
Migrate WBTC to Maker-vDAI

### DIFF
--- a/vWBTC.md
+++ b/vWBTC.md
@@ -2,7 +2,7 @@
 |Strategy | Weight |
 |-------: | --------|
 |Compound | 0%     |
-|Compound Leverage | 95%  |
-|Maker vDAI | 0%     |
+|Compound Leverage | 0%  |
+|Maker vDAI | 98%     |
 |Aave | 0%     |
-|Pool buffer | 5%     |
+|Pool buffer | 2%     |

--- a/vWBTC.md
+++ b/vWBTC.md
@@ -3,6 +3,6 @@
 |-------: | --------|
 |Compound | 0%     |
 |Compound Leverage | 0%  |
-|Maker vDAI | 98%     |
+|Maker vDAI | 95%     |
 |Aave | 0%     |
-|Pool buffer | 2%     |
+|Pool buffer | 5%     |

--- a/vWBTC.md
+++ b/vWBTC.md
@@ -1,0 +1,8 @@
+# vLINK pool
+|Strategy | Weight |
+|-------: | --------|
+|Compound | 0%     |
+|Compound Leverage | 95%  |
+|Maker vDAI | 0%     |
+|Aave | 0%     |
+|Pool buffer | 5%     |


### PR DESCRIPTION
Migrate 95% of vWBTC (5% kept as buffer) to Maker-vDAI at conservative 275% collateral ratio.

This translates to almost 2x increase in WBTC APY.