### PR TITLE
vUNI strategy update

### DIFF
--- a/vaDAI.md
+++ b/vaDAI.md
@@ -4,4 +4,5 @@
 |Convex | 85%     |
 |Yearn| 0%     |
 |Rari fuse pool#23 | 10%     |
-|Pool buffer | 5%     |
+|Compound Leverage | 0.1%     |
+|Pool buffer | 4.9%     |


### PR DESCRIPTION
Compound leverage strategy is in beta testing currently. UNI and COMP are two potential pool for compound leverage strategy because borrow rate is -tive( factoring COMP emission) for these two tokens . We can allocate very small weight to this strategy for beta test. Proposing following changes

**Current** 
|Strategy | Weight |
|-------: | --------|
|Convex | 85%     |
|Yearn| 0%     |
|Rari fuse pool#23 | 10%     |
|Pool buffer | 5%     |

**Proposed change**
|Strategy | Weight |
|-------: | --------|
|Convex | 85%     |
|Yearn| 0%     |
|Rari fuse pool#23 | 10%     |
|Compound Leverage | 0.1%     |
|Pool buffer | 4.9%     |