### PR TITLE
Migrate vUSDT from CREAM to Aave

### DIFF
--- a/vUSDT
+++ b/vUSDT
@@ -1,0 +1,7 @@
+# vUSDT pool
+|Strategy | Weight |
+|-------: | --------|
+|Compound | 0%     |
+|CREAM | 0%     |
+|Aave | 95%     |
+|Pool buffer | 5%     |


### PR DESCRIPTION
Currently, USDT is:
* 75% Aave
* 20% CREAM
* 5% pool buffer

CREAM yield lags well below Aave. Migrate back to Aave: 95% Aave  5% Buffer