### PR TITLE
Update weight of Convex and Compound leverage strategy in vaWBTC pool

### DIFF
--- a/vaWBTC.md
+++ b/vaWBTC.md
@@ -2,7 +2,7 @@
 |Strategy | Weight |
 |-------: | --------|
 |Curve| 0%     |
-|Curve Convex| 15%     |
+|Curve Convex| 0%     |
 |Rari fuse pool#23 | 9%     |
-|Maker WBTC | 70%    |
-|Pool buffer | 6%     |
+|Maker WBTC | 86%    |
+|Pool buffer | 5%     |


### PR DESCRIPTION
Low APY in Convex. Reduce weight to 0.  WBTC is potential candidate for leveraging in Compound. Borrow APY is  ~ -2%. After leveraging up to 3 level, expected APY from compound is 2.4%.  Lets gradually increase compound leverage strategy weigh. Starting with 5%. 
**Current weights**

|Strategy | Weight |
|-------: | --------|
|Convex | 15%     |
|Yearn| 0%     |
|Maker-vaDAI | 70%   | 
|Rari fuse pool#23 | 9%     |
|Compound Leverage | 0%     |
|Pool buffer | 6%     |

**Change this to** 

|Strategy | Weight |
|-------: | --------|
|Convex | 0%     |
|Yearn| 0%     |
|Maker-vaDAI | 81%   | 
|Rari fuse pool#23 | 9%     |
|Compound Leverage | 5%     |
|Pool buffer | 5%     |