### PR TITLE
Migrate vUNI from Aave to Compound

### DIFF
--- a/vUNI.md
+++ b/vUNI.md
@@ -1,7 +1,7 @@
 # vUNI pool
 |Strategy | Weight |
 |-------: | --------|
-|Compound | 0%     |
+|Compound | 95%     |
 |Maker Compound | 0%     |
-|Aave | 95%     |
+|Aave | 0%     |
 |Pool buffer | 5%     |


### PR DESCRIPTION
Move UNI assets from Aave (0.09% APY) to Compound (0.72% APY)

UNI no longer receives stkAave rewards and will remain lower APY until we have borrow capabilities from Aave employed.