### PR TITLE
Migrate vUSDT assets from Aave to Compound

### DIFF
--- a/vUSDT.md
+++ b/vUSDT.md
@@ -1,7 +1,6 @@
 # vUSDT pool
 |Strategy | Weight |
 |-------: | --------|
-|Compound | 0%     |
-|CREAM | 0%     |
-|Aave | 95%     |
+|Compound | 95%     |
+|Aave | 0%     |
 |Pool buffer | 5%     |


### PR DESCRIPTION
Aave rewards/APY continue to trend lower than Compound: 3.77% on Aave vs 5.41% on Compound