### PR TITLE
Migrate 20% of FEI weight from Aave to Rari Fuse #6

### DIFF
--- a/vaFEI.md
+++ b/vaFEI.md
@@ -1,8 +1,8 @@
 # vaFEI pool
 |Strategy | Weight |
 |-------: | --------|
-|Aave              | 70%     |
-|Rari fuse pool#6  | 0%     |
+|Aave              | 50%     |
+|Rari fuse pool#6  | 20%     |
 |Rari fuse pool#18 | 25%     |
 |Rari fuse pool#27 | 0%     |
 |Pool buffer | 5%     |


### PR DESCRIPTION
Aave utilization rates trending down as TRIBE rewards for borrowers have decreased. <3% APY on Aave, >15% on Pool 6