### PR TITLE
Migrate DPI weight from Homora to Aave

### DIFF
--- a/vaDPI.md
+++ b/vaDPI.md
@@ -1,7 +1,8 @@
 # vaDPI pool
 |Strategy | Weight |
 |-------: | --------|
-|Alpha-Lend | 95%     |
+|Alpha-Lend | 50%     |
+|Aave | 45% |
 |Pool buffer | 5%     |
 
 Pool limit: $25mm


### PR DESCRIPTION
Move 50% of DPI to Aave (0.72% APY) from Alpha Homora (0.20% APY)