### PR TITLE
Update weight of Compound leverage strategy

### DIFF
--- a/mainnet/vaLINK.md
+++ b/mainnet/vaLINK.md
@@ -1,6 +1,6 @@
 # vaLINK pool
 |Strategy | Weight |
 |-------: | --------|
-|Maker | 45%    |
-|Compound Leverage | 50%     |
+|Maker | 0%    |
+|Compound Leverage | 90%     |
 |Pool buffer | 5%     |

--- a/mainnet/vaLINK.md
+++ b/mainnet/vaLINK.md
@@ -2,5 +2,5 @@
 |Strategy | Weight |
 |-------: | --------|
 |Maker | 0%    |
-|Compound Leverage | 90%     |
+|Compound Leverage | 95%     |
 |Pool buffer | 5%     |


### PR DESCRIPTION
Compound leverage strategy of vaLINK is doing better based on recent data.  Lets set 95% weight of compound leverage only.