### PR TITLE
FEI weight rebalance with new strategy deployed

### DIFF
--- a/mainnet/vaFEI.md
+++ b/mainnet/vaFEI.md
@@ -1,7 +1,8 @@
 # vaFEI pool
 |Strategy | Weight |
 |-------: | --------|
-|Aave              | 50%     |
+|Convex d3pool | 50%
+|Aave              | 0%     |
 |Rari fuse pool#6  | 20%     |
 |Rari fuse pool#18 | 25%     |
 |Rari fuse pool#27 | 0%     |


### PR DESCRIPTION
Once d3pool Convex strategy is ready, leave Aave in favor of Convex