### PR TITLE
Update strategy weight of vaFEI

### DIFF
--- a/mainnet/vaFEI.md
+++ b/mainnet/vaFEI.md
@@ -1,9 +1,10 @@
 # vaFEI pool
 |Strategy | Weight |
 |-------: | --------|
-|Aave              | 50%     |
-|Rari fuse pool#6  | 20%     |
-|Rari fuse pool#18 | 25%     |
+|Aave              | 0%     |
+|Rari fuse pool#6  | 0%     |
+|Rari fuse pool#18 | 0%     |
+|Rari fuse pool#8 | 95%     |
 |Rari fuse pool#27 | 0%     |
 |Pool buffer | 5%     |
 


### PR DESCRIPTION
Proposed new weight of strategy. 

1. Update weight of strategies as suggested
2. Call rariStrategy#18.migrateFusePool(8). This will withdraw from 18 and deposit to 8.  This is one way to reuse rari strategy for new fusePool. We dont need to deploy new strategy if other strategy is planned to set 0 weight. 
3. Confirm after migration, strategy has new fTokens.