### PR TITLE
Deploy vaUSDC to rari fuse #136

### DIFF
--- a/mainnet/vaUSDC.md
+++ b/mainnet/vaUSDC.md
@@ -2,6 +2,7 @@
 |Strategy | Weight |
 |-------: | --------|
 |Rari fuse pool#18 | 0% |
-|Rari fuse pool#6  | 45% |
+|Rari fuse pool#6  | 20% |
+|Rari fuse pool#136| 25% |
 |Convex4 FRAX | 50% |
-|Pool buffer |      |
+|Pool buffer |   5%   |


### PR DESCRIPTION
Deploy Rari Fuse #136 for vaUSDC

high double digit APY with meaningful TVL ($16.2mm)