### PR TITLE
Update weight in vaWBTC

### DIFF
--- a/mainnet/vaWBTC.md
+++ b/mainnet/vaWBTC.md
@@ -4,6 +4,6 @@
 |Curve| 0%     |
 |Curve Convex| 0%     |
 |Rari fuse pool#23 | 0%     |
-|Maker WBTC-C | 0%    |
-|Compound Leverage | 95% |
+|Maker WBTC-C | 95%    |
+|Compound Leverage | 0% |
 |Pool buffer | 5%     |


### PR DESCRIPTION
Compound leverage strategy is no longer profitable. Set weight 0 and increase weight of MakerWBTC_C strategy.  0x70900C53202297Bd7Cd4ED1635486D84E3982484